### PR TITLE
Fuzz with SIMD enabled

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,6 +13,7 @@ libfuzzer-sys = "0.4"
 
 [dependencies.jpeg-encoder]
 path = ".."
+features = ["simd"]
 
 # Prevent this from interfering with workspaces
 [workspace]


### PR DESCRIPTION
So that the fuzzer can actually reach the unsafe code.

I've run every fuzz target for a few hours in this mode and didn't find any memory safety issues yet.