### PR TITLE
Fewer copies when writing metadata

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -353,11 +353,7 @@ impl<W: JfifWrite> Encoder<W> {
     /// # Errors
     ///
     /// Returns an error if the segment number is invalid or data exceeds the allowed size
-    pub fn add_app_segment(&mut self, segment_nr: u8, data: &[u8]) -> Result<(), EncodingError> {
-        self.add_app_segment_internal(segment_nr, data.to_vec())
-    }
-
-    fn add_app_segment_internal(
+    pub fn add_app_segment(
         &mut self,
         segment_nr: u8,
         data: Vec<u8>,
@@ -400,7 +396,7 @@ impl<W: JfifWrite> Encoder<W> {
             chunk_data.push(num_chunks as u8);
             chunk_data.extend_from_slice(data);
 
-            self.add_app_segment_internal(2, chunk_data)?;
+            self.add_app_segment(2, chunk_data)?;
         }
 
         Ok(())
@@ -421,7 +417,7 @@ impl<W: JfifWrite> Encoder<W> {
         let mut formatted = EXIF_HEADER.to_vec();
         formatted.extend_from_slice(data);
 
-        self.add_app_segment(1, &formatted)
+        self.add_app_segment(1, formatted)
     }
 
     /// Encode an image

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -354,12 +354,20 @@ impl<W: JfifWrite> Encoder<W> {
     ///
     /// Returns an error if the segment number is invalid or data exceeds the allowed size
     pub fn add_app_segment(&mut self, segment_nr: u8, data: &[u8]) -> Result<(), EncodingError> {
+        self.add_app_segment_internal(segment_nr, data.to_vec())
+    }
+
+    fn add_app_segment_internal(
+        &mut self,
+        segment_nr: u8,
+        data: Vec<u8>,
+    ) -> Result<(), EncodingError> {
         if segment_nr == 0 || segment_nr > 15 {
             Err(EncodingError::InvalidAppSegment(segment_nr))
         } else if data.len() > 65533 {
             Err(EncodingError::AppSegmentTooLarge(data.len()))
         } else {
-            self.app_segments.push((segment_nr, data.to_vec()));
+            self.app_segments.push((segment_nr, data));
             Ok(())
         }
     }
@@ -385,16 +393,14 @@ impl<W: JfifWrite> Encoder<W> {
             return Err(EncodingError::IccTooLarge(data.len()));
         }
 
-        let mut chunk_data = Vec::with_capacity(MAX_CHUNK_LENGTH);
-
         for (i, data) in data.chunks(MAX_CHUNK_LENGTH).enumerate() {
-            chunk_data.clear();
+            let mut chunk_data = Vec::with_capacity(MAX_CHUNK_LENGTH);
             chunk_data.extend_from_slice(MARKER);
             chunk_data.push(i as u8 + 1);
             chunk_data.push(num_chunks as u8);
             chunk_data.extend_from_slice(data);
 
-            self.add_app_segment(2, &chunk_data)?;
+            self.add_app_segment_internal(2, chunk_data)?;
         }
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -473,7 +473,7 @@ mod tests {
         let mut result = Vec::new();
         let mut encoder = Encoder::new(&mut result, 100);
 
-        encoder.add_app_segment(15, b"HOHOHO\0").unwrap();
+        encoder.add_app_segment(15, b"HOHOHO\0".to_vec()).unwrap();
 
         encoder
             .encode(&data, width, height, ColorType::Rgb)


### PR DESCRIPTION
I made a new internal function to avoid breaking the public API.

This would also speed up #19