### PR TITLE
NEON-accelerated RGB->YCbCr

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,8 @@ extern crate core;
 
 #[cfg(all(feature = "simd", any(target_arch = "x86", target_arch = "x86_64")))]
 mod avx2;
+#[cfg(all(feature = "simd", target_feature = "neon"))]
+mod neon;
 mod encoder;
 mod error;
 mod fdct;

--- a/src/neon.rs
+++ b/src/neon.rs
@@ -1,0 +1,3 @@
+mod ycbcr;
+
+pub(crate) use ycbcr::*;

--- a/src/neon/ycbcr.rs
+++ b/src/neon/ycbcr.rs
@@ -1,0 +1,57 @@
+#[cfg(target_arch = "aarch64")]
+use std::arch::aarch64::*;
+
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+#[unsafe(no_mangle)]
+#[inline(never)]
+unsafe fn rgb_to_ycbcr_simd(r: int32x4_t, g: int32x4_t, b: int32x4_t) -> (int32x4_t, int32x4_t, int32x4_t) {
+    // To avoid floating point math this scales everything by 2^16 which gives
+    // a precision of approx 4 digits.
+    //
+    // Non scaled conversion:
+    // Y  =  0.29900 * R + 0.58700 * G + 0.11400 * B
+    // Cb = -0.16874 * R - 0.33126 * G + 0.50000 * B  + 128
+    // Cr =  0.50000 * R - 0.41869 * G - 0.08131 * B  + 128
+
+    let y1_mul = vdupq_n_s32(19595);
+    let y2_mul = vdupq_n_s32(38470);
+    let y3_mul = vdupq_n_s32(7471);
+
+    let cb1_mul = vdupq_n_s32(-11059);
+    let cb2_mul = vdupq_n_s32(21709);
+    let cb3_mul = vdupq_n_s32(32768);
+    let cb4_mul = vdupq_n_s32(128 << 16);
+
+    let cr1_mul = vdupq_n_s32(32768);
+    let cr2_mul = vdupq_n_s32(27439);
+    let cr3_mul = vdupq_n_s32(5329);
+    let cr4_mul = vdupq_n_s32(128 << 16);
+
+    // Y = y1_mul * r + y2_mul * g + y3_mul * b
+    let y = vmlaq_s32(vmlaq_s32(vmulq_s32(y1_mul, r), y2_mul, g), y3_mul, b);
+    
+    // Cb = cb1_mul * r - cb2_mul * g + cb3_mul * b + cb4_mul
+    let cb = vaddq_s32(
+        vmlaq_s32(vmlsq_s32(vmulq_s32(cb1_mul, r), cb2_mul, g), cb3_mul, b),
+        cb4_mul
+    );
+    
+    // Cr = cr1_mul * r - cr2_mul * g - cr3_mul * b + cr4_mul
+    let cr = vaddq_s32(
+        vmlsq_s32(vmlsq_s32(vmulq_s32(cr1_mul, r), cr2_mul, g), cr3_mul, b),
+        cr4_mul
+    );
+
+    #[inline(always)]
+    unsafe fn round_shift(v: int32x4_t) -> int32x4_t {
+        let round = vdupq_n_s32(0x7FFF);
+        vshrq_n_s32(vaddq_s32(v, round), 16)
+    }
+
+    (
+        round_shift(y),
+        round_shift(cb),
+        round_shift(cr)
+    )
+}

--- a/src/neon/ycbcr.rs
+++ b/src/neon/ycbcr.rs
@@ -138,18 +138,18 @@ fn store_i32x4(arr: &mut [i32], vec: int32x4_t) {
 
 #[inline]
 #[target_feature(enable = "neon")]
-fn load_u8_to_i32<const stride: usize>(values: &[u8]) -> [i32; 8] {
+fn load_u8_to_i32<const STRIDE: usize>(values: &[u8]) -> [i32; 8] {
     // avoid bounds checks further down
-    let values = &values[..7*stride + 1];
+    let values = &values[..7*STRIDE + 1];
 
     [
-        values[0 * stride] as i32,
-        values[1 * stride] as i32,
-        values[2 * stride] as i32,
-        values[3 * stride] as i32,
-        values[4 * stride] as i32,
-        values[5 * stride] as i32,
-        values[6 * stride] as i32,
-        values[7 * stride] as i32,
+        values[0 * STRIDE] as i32,
+        values[1 * STRIDE] as i32,
+        values[2 * STRIDE] as i32,
+        values[3 * STRIDE] as i32,
+        values[4 * STRIDE] as i32,
+        values[5 * STRIDE] as i32,
+        values[6 * STRIDE] as i32,
+        values[7 * STRIDE] as i32,
     ]
 }

--- a/src/neon/ycbcr.rs
+++ b/src/neon/ycbcr.rs
@@ -1,11 +1,11 @@
+#[cfg(target_arch = "arm")] // 32-bit ARM  with NEON
+use std::arch::arm::*;
+
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 
-#[cfg(target_arch = "aarch64")]
 #[target_feature(enable = "neon")]
-#[unsafe(no_mangle)]
-#[inline(never)]
-unsafe fn rgb_to_ycbcr_simd(
+fn rgb_to_ycbcr_simd(
     r: [i32; 8],
     g: [i32; 8],
     b: [i32; 8],
@@ -19,12 +19,12 @@ unsafe fn rgb_to_ycbcr_simd(
     // Cr =  0.50000 * R - 0.41869 * G - 0.08131 * B  + 128
 
     // Load input arrays into NEON registers (2 registers per channel)
-    let r_lo = vld1q_s32(r.as_ptr());
-    let r_hi = vld1q_s32(r.as_ptr().add(4));
-    let g_lo = vld1q_s32(g.as_ptr());
-    let g_hi = vld1q_s32(g.as_ptr().add(4));
-    let b_lo = vld1q_s32(b.as_ptr());
-    let b_hi = vld1q_s32(b.as_ptr().add(4));
+    let r_lo = load_i32x4(r[..4]);
+    let r_hi = load_i32x4(r[4..]);
+    let g_lo = load_i32x4(g[..4]);
+    let g_hi = load_i32x4(g[4..]);
+    let b_lo = load_i32x4(b[..4]);
+    let b_hi = load_i32x4(b[4..]);
 
     let y1_mul = vdupq_n_s32(19595);
     let y2_mul = vdupq_n_s32(38470);
@@ -86,8 +86,9 @@ unsafe fn rgb_to_ycbcr_simd(
         cr4_mul,
     );
 
-    #[inline(always)]
-    unsafe fn round_shift(v: int32x4_t) -> int32x4_t {
+    #[target_feature(enable = "neon")]
+    #[inline]
+    fn round_shift(v: int32x4_t) -> int32x4_t {
         let round = vdupq_n_s32(0x7FFF);
         vshrq_n_s32(vaddq_s32(v, round), 16)
     }
@@ -113,4 +114,24 @@ unsafe fn rgb_to_ycbcr_simd(
     vst1q_s32(cr_out.as_mut_ptr().add(4), cr_hi);
 
     (y_out, cb_out, cr_out)
+}
+
+#[target_feature(enable = "neon")]
+fn load_i32x4(arr: &[i32; 4]) -> int32x4_t {
+    // Safety preconditions. Optimized away in release mode, no runtime cost.
+    assert!(core::mem::size_of::<int32x4_t>() == core::mem::size_of::<[i32; 4]>());
+    // SAFETY: size checked above.
+    // NEON load intrinsics do not care if data is aligned.
+    // Both types are plain old data: no pointers, lifetimes, etc.
+    vld1q_s32(arr.as_ptr())
+}
+
+#[target_feature(enable = "neon")]
+fn store_i32x4(arr: &mut [i32], vec: int32x4_t) {
+    // Safety preconditions. Optimized away in release mode, no runtime cost.
+    assert!(arr.len() >= core::mem::size_of::<int32x4_t>());
+    // SAFETY: size checked above.
+    // NEON load intrinsics do not care if data is aligned.
+    // Both types are plain old data: no pointers, lifetimes, etc.
+    vst1q_s32(arr.as_mut_ptr(), vec);
 }

--- a/src/neon/ycbcr.rs
+++ b/src/neon/ycbcr.rs
@@ -135,3 +135,21 @@ fn store_i32x4(arr: &mut [i32], vec: int32x4_t) {
     // Both types are plain old data: no pointers, lifetimes, etc.
     vst1q_s32(arr.as_mut_ptr(), vec);
 }
+
+#[inline]
+#[target_feature(enable = "neon")]
+fn load_u8_to_i32<const stride: usize>(values: &[u8]) -> [i32; 8] {
+    // avoid bounds checks further down
+    let values = &values[..7*stride + 1];
+
+    [
+        values[0 * stride] as i32,
+        values[1 * stride] as i32,
+        values[2 * stride] as i32,
+        values[3 * stride] as i32,
+        values[4 * stride] as i32,
+        values[5 * stride] as i32,
+        values[6 * stride] as i32,
+        values[7 * stride] as i32,
+    ]
+}


### PR DESCRIPTION
This is a sketch of a NEON-accelerated implementation for RGB->YCbCr conversion, adapted from  #13 with some assistance from Claude to translate std::simd into the corresponding intrinsics, and with scaffolding adapted from  #17.

I'm not entirely sure how to wire it up to the rest of the code, so it wasn't tested or benchmarked yet.