### PR TITLE
Optionally use wide crate for DCT, which adds support for ARM64, WASM and SSE2 on stable

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,6 +29,8 @@ jobs:
       run: cargo build --verbose --features simd
     - name: Run tests
       run: cargo test --verbose --features simd
+    - name: Run tests use_wide
+      run: cargo test --verbose --features use_wide
 
   no_std:
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/vstroebel/jpeg-encoder"
 rust-version = "1.61"
 
 [features]
-default = ["std", "use_wide"]
+default = ["std"]
 simd = ["std"]
 std = []
 use_wide = ["wide", "bytemuck"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ use_wide = ["wide", "bytemuck"]
 benchmark = []
 
 [dependencies]
-wide = { version = "0.7", optional = true, default-features = false }
-bytemuck = { version = "1", optional = true, default-features = false }
+wide = { version = "1.0", optional = true, default-features = false }
+bytemuck = { version = "1.24", optional = true, default-features = false }
 
 [dev-dependencies]
 jpeg-decoder = { version = "0.3", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,17 @@ repository = "https://github.com/vstroebel/jpeg-encoder"
 rust-version = "1.61"
 
 [features]
-default = ["std"]
+default = ["std", "use_wide"]
 simd = ["std"]
 std = []
+use_wide = ["wide", "bytemuck"]
 
 # DO NOT USE THIS IN PRODUCTION. Expose several internal functions for benchmark purposes.
 benchmark = []
 
 [dependencies]
+wide = { version = "0.7", optional = true, default-features = false }
+bytemuck = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
 jpeg-decoder = { version = "0.3", default-features = false }

--- a/criterion/benches/fdct.rs
+++ b/criterion/benches/fdct.rs
@@ -4,14 +4,13 @@ use jpeg_encoder::fdct;
 use std::time::Duration;
 
 const INPUT1: [i16; 64] = [
-    -70, -71, -70, -68, -67, -67, -67, -67, -72, -73, -72, -70, -69, -69, -68, -69, -75, -76,
-    -74, -73, -73, -72, -71, -70, -77, -78, -77, -75, -76, -75, -73, -71, -78, -77, -77, -76,
-    -79, -77, -76, -75, -78, -78, -77, -77, -77, -77, -78, -77, -79, -79, -78, -78, -78, -78,
-    -79, -78, -80, -79, -78, -78, -81, -80, -78, -76,
+    -70, -71, -70, -68, -67, -67, -67, -67, -72, -73, -72, -70, -69, -69, -68, -69, -75, -76, -74,
+    -73, -73, -72, -71, -70, -77, -78, -77, -75, -76, -75, -73, -71, -78, -77, -77, -76, -79, -77,
+    -76, -75, -78, -78, -77, -77, -77, -77, -78, -77, -79, -79, -78, -78, -78, -78, -79, -78, -80,
+    -79, -78, -78, -81, -80, -78, -76,
 ];
 
 fn criterion_benchmark(c: &mut Criterion) {
-
     let mut group = c.benchmark_group("fdct");
     group.measurement_time(Duration::from_secs(60));
     group.warm_up_time(Duration::from_secs(10));
@@ -19,9 +18,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     group.bench_function("default fdct", |b| {
         b.iter(|| {
             let mut input = INPUT1.clone();
-            fdct(
-                black_box(&mut input),
-            );
+            fdct(black_box(&mut input));
             black_box(&input);
         })
     });
@@ -32,9 +29,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             use jpeg_encoder::fdct_avx2;
 
             let mut input = INPUT1.clone();
-            fdct_avx2(
-                black_box(&mut input),
-            );
+            fdct_avx2(black_box(&mut input));
             black_box(&input);
         })
     });

--- a/criterion/benches/fdct.rs
+++ b/criterion/benches/fdct.rs
@@ -4,13 +4,14 @@ use jpeg_encoder::fdct;
 use std::time::Duration;
 
 const INPUT1: [i16; 64] = [
-    -70, -71, -70, -68, -67, -67, -67, -67, -72, -73, -72, -70, -69, -69, -68, -69, -75, -76, -74,
-    -73, -73, -72, -71, -70, -77, -78, -77, -75, -76, -75, -73, -71, -78, -77, -77, -76, -79, -77,
-    -76, -75, -78, -78, -77, -77, -77, -77, -78, -77, -79, -79, -78, -78, -78, -78, -79, -78, -80,
-    -79, -78, -78, -81, -80, -78, -76,
+    -70, -71, -70, -68, -67, -67, -67, -67, -72, -73, -72, -70, -69, -69, -68, -69, -75, -76,
+    -74, -73, -73, -72, -71, -70, -77, -78, -77, -75, -76, -75, -73, -71, -78, -77, -77, -76,
+    -79, -77, -76, -75, -78, -78, -77, -77, -77, -77, -78, -77, -79, -79, -78, -78, -78, -78,
+    -79, -78, -80, -79, -78, -78, -81, -80, -78, -76,
 ];
 
 fn criterion_benchmark(c: &mut Criterion) {
+
     let mut group = c.benchmark_group("fdct");
     group.measurement_time(Duration::from_secs(60));
     group.warm_up_time(Duration::from_secs(10));
@@ -18,7 +19,9 @@ fn criterion_benchmark(c: &mut Criterion) {
     group.bench_function("default fdct", |b| {
         b.iter(|| {
             let mut input = INPUT1.clone();
-            fdct(black_box(&mut input));
+            fdct(
+                black_box(&mut input),
+            );
             black_box(&input);
         })
     });
@@ -29,7 +32,9 @@ fn criterion_benchmark(c: &mut Criterion) {
             use jpeg_encoder::fdct_avx2;
 
             let mut input = INPUT1.clone();
-            fdct_avx2(black_box(&mut input));
+            fdct_avx2(
+                black_box(&mut input),
+            );
             black_box(&input);
         })
     });

--- a/src/fdct.rs
+++ b/src/fdct.rs
@@ -71,6 +71,9 @@
  * scaled fixed-point arithmetic, with a minimal number of shifts.
  */
 
+use bytemuck::cast;
+use wide::{i16x8, i32x8};
+
 const CONST_BITS: i32 = 13;
 const PASS1_BITS: i32 = 2;
 
@@ -87,17 +90,9 @@ const FIX_2_053119869: i32 = 16819;
 const FIX_2_562915447: i32 = 20995;
 const FIX_3_072711026: i32 = 25172;
 
-const DCT_SIZE: usize = 8;
-
-#[inline(always)]
-fn descale(x: i32, n: i32) -> i32 {
+fn descale_w(x: i32x8, n: i32) -> i32x8 {
     // right shift with rounding
     (x + (1 << (n - 1))) >> n
-}
-
-#[inline(always)]
-fn into_el(v: i32) -> i16 {
-    v as i16
 }
 
 #[allow(clippy::erasing_op)]
@@ -107,136 +102,129 @@ pub fn fdct(data: &mut [i16; 64]) {
     /* Note results are scaled up by sqrt(8) compared to a true DCT; */
     /* furthermore, we scale the results by 2**PASS1_BITS. */
 
-    let mut data2 = [0i32; 64];
+    let data_w = i16x8::transpose(cast(*data)).map(i32x8::from_i16x8);
 
-    for y in 0..8 {
-        let offset = y * 8;
+    let tmp0 = data_w[0] + data_w[7];
+    let tmp7 = data_w[0] - data_w[7];
+    let tmp1 = data_w[1] + data_w[6];
+    let tmp6 = data_w[1] - data_w[6];
+    let tmp2 = data_w[2] + data_w[5];
+    let tmp5 = data_w[2] - data_w[5];
+    let tmp3 = data_w[3] + data_w[4];
+    let tmp4 = data_w[3] - data_w[4];
 
-        let tmp0 = i32::from(data[offset + 0]) + i32::from(data[offset + 7]);
-        let tmp7 = i32::from(data[offset + 0]) - i32::from(data[offset + 7]);
-        let tmp1 = i32::from(data[offset + 1]) + i32::from(data[offset + 6]);
-        let tmp6 = i32::from(data[offset + 1]) - i32::from(data[offset + 6]);
-        let tmp2 = i32::from(data[offset + 2]) + i32::from(data[offset + 5]);
-        let tmp5 = i32::from(data[offset + 2]) - i32::from(data[offset + 5]);
-        let tmp3 = i32::from(data[offset + 3]) + i32::from(data[offset + 4]);
-        let tmp4 = i32::from(data[offset + 3]) - i32::from(data[offset + 4]);
+    /* Even part per LL&M figure 1 --- note that published figure is faulty;
+     * rotator "sqrt(2)*c1" should be "sqrt(2)*c6".
+     */
 
-        /* Even part per LL&M figure 1 --- note that published figure is faulty;
-         * rotator "sqrt(2)*c1" should be "sqrt(2)*c6".
-         */
+    let tmp10 = tmp0 + tmp3;
+    let tmp13 = tmp0 - tmp3;
+    let tmp11 = tmp1 + tmp2;
+    let tmp12 = tmp1 - tmp2;
 
-        let tmp10 = tmp0 + tmp3;
-        let tmp13 = tmp0 - tmp3;
-        let tmp11 = tmp1 + tmp2;
-        let tmp12 = tmp1 - tmp2;
+    let data_0 = (tmp10 + tmp11) << PASS1_BITS;
+    let data_4 = (tmp10 - tmp11) << PASS1_BITS;
 
-        data2[offset + 0] = (tmp10 + tmp11) << PASS1_BITS;
-        data2[offset + 4] = (tmp10 - tmp11) << PASS1_BITS;
+    let z1 = (tmp12 + tmp13) * FIX_0_541196100;
+    let data_2 = descale_w(z1 + (tmp13 * FIX_0_765366865), CONST_BITS - PASS1_BITS);
+    let data_6 = descale_w(z1 + (tmp12 * -FIX_1_847759065), CONST_BITS - PASS1_BITS);
 
-        let z1 = (tmp12 + tmp13) * FIX_0_541196100;
-        data2[offset + 2] = descale(
-            z1 + (tmp13 * FIX_0_765366865),
-            CONST_BITS - PASS1_BITS,
-        );
-        data2[offset + 6] = descale(
-            z1 + (tmp12 * -FIX_1_847759065),
-            CONST_BITS - PASS1_BITS,
-        );
+    /* Odd part per figure 8 --- note paper omits factor of sqrt(2).
+     * cK represents cos(K*pi/16).
+     * i0..i3 in the paper are tmp4..tmp7 here.
+     */
 
-        /* Odd part per figure 8 --- note paper omits factor of sqrt(2).
-         * cK represents cos(K*pi/16).
-         * i0..i3 in the paper are tmp4..tmp7 here.
-         */
+    let z1 = tmp4 + tmp7;
+    let z2 = tmp5 + tmp6;
+    let z3 = tmp4 + tmp6;
+    let z4 = tmp5 + tmp7;
+    let z5 = (z3 + z4) * FIX_1_175875602; /* sqrt(2) * c3 */
 
-        let z1 = tmp4 + tmp7;
-        let z2 = tmp5 + tmp6;
-        let z3 = tmp4 + tmp6;
-        let z4 = tmp5 + tmp7;
-        let z5 = (z3 + z4) * FIX_1_175875602; /* sqrt(2) * c3 */
+    let tmp4 = tmp4 * FIX_0_298631336; /* sqrt(2) * (-c1+c3+c5-c7) */
+    let tmp5 = tmp5 * FIX_2_053119869; /* sqrt(2) * ( c1+c3-c5+c7) */
+    let tmp6 = tmp6 * FIX_3_072711026; /* sqrt(2) * ( c1+c3+c5-c7) */
+    let tmp7 = tmp7 * FIX_1_501321110; /* sqrt(2) * ( c1+c3-c5-c7) */
+    let z1 = z1 * -FIX_0_899976223; /* sqrt(2) * ( c7-c3) */
+    let z2 = z2 * -FIX_2_562915447; /* sqrt(2) * (-c1-c3) */
+    let z3 = z3 * -FIX_1_961570560; /* sqrt(2) * (-c3-c5) */
+    let z4 = z4 * -FIX_0_390180644; /* sqrt(2) * ( c5-c3) */
 
-        let tmp4 = tmp4 * FIX_0_298631336; /* sqrt(2) * (-c1+c3+c5-c7) */
-        let tmp5 = tmp5 * FIX_2_053119869; /* sqrt(2) * ( c1+c3-c5+c7) */
-        let tmp6 = tmp6 * FIX_3_072711026; /* sqrt(2) * ( c1+c3+c5-c7) */
-        let tmp7 = tmp7 * FIX_1_501321110; /* sqrt(2) * ( c1+c3-c5-c7) */
-        let z1 = z1 * -FIX_0_899976223; /* sqrt(2) * ( c7-c3) */
-        let z2 = z2 * -FIX_2_562915447; /* sqrt(2) * (-c1-c3) */
-        let z3 = z3 * -FIX_1_961570560; /* sqrt(2) * (-c3-c5) */
-        let z4 = z4 * -FIX_0_390180644; /* sqrt(2) * ( c5-c3) */
+    let z3 = z3 + z5;
+    let z4 = z4 + z5;
 
-        let z3 = z3 + z5;
-        let z4 = z4 + z5;
+    let data_7 = descale_w(tmp4 + z1 + z3, CONST_BITS - PASS1_BITS);
+    let data_5 = descale_w(tmp5 + z2 + z4, CONST_BITS - PASS1_BITS);
+    let data_3 = descale_w(tmp6 + z2 + z3, CONST_BITS - PASS1_BITS);
+    let data_1 = descale_w(tmp7 + z1 + z4, CONST_BITS - PASS1_BITS);
 
-        data2[offset + 7] = descale(tmp4 + z1 + z3, CONST_BITS - PASS1_BITS);
-        data2[offset + 5] = descale(tmp5 + z2 + z4, CONST_BITS - PASS1_BITS);
-        data2[offset + 3] = descale(tmp6 + z2 + z3, CONST_BITS - PASS1_BITS);
-        data2[offset + 1] = descale(tmp7 + z1 + z4, CONST_BITS - PASS1_BITS);
-    }
+    let data_w = i32x8::transpose([
+        data_0, data_1, data_2, data_3, data_4, data_5, data_6, data_7,
+    ]);
 
     /* Pass 2: process columns.
      * We remove the PASS1_BITS scaling, but leave the results scaled up
      * by an overall factor of 8.
      */
 
-    for x in 0..8 {
-        let tmp0 = data2[DCT_SIZE * 0 + x] + data2[DCT_SIZE * 7 + x];
-        let tmp7 = data2[DCT_SIZE * 0 + x] - data2[DCT_SIZE * 7 + x];
-        let tmp1 = data2[DCT_SIZE * 1 + x] + data2[DCT_SIZE * 6 + x];
-        let tmp6 = data2[DCT_SIZE * 1 + x] - data2[DCT_SIZE * 6 + x];
-        let tmp2 = data2[DCT_SIZE * 2 + x] + data2[DCT_SIZE * 5 + x];
-        let tmp5 = data2[DCT_SIZE * 2 + x] - data2[DCT_SIZE * 5 + x];
-        let tmp3 = data2[DCT_SIZE * 3 + x] + data2[DCT_SIZE * 4 + x];
-        let tmp4 = data2[DCT_SIZE * 3 + x] - data2[DCT_SIZE * 4 + x];
+    let tmp0 = data_w[0] + data_w[7];
+    let tmp7 = data_w[0] - data_w[7];
+    let tmp1 = data_w[1] + data_w[6];
+    let tmp6 = data_w[1] - data_w[6];
+    let tmp2 = data_w[2] + data_w[5];
+    let tmp5 = data_w[2] - data_w[5];
+    let tmp3 = data_w[3] + data_w[4];
+    let tmp4 = data_w[3] - data_w[4];
 
-        /* Even part per LL&M figure 1 --- note that published figure is faulty;
-         * rotator "sqrt(2)*c1" should be "sqrt(2)*c6".
-         */
+    /* Even part per LL&M figure 1 --- note that published figure is faulty;
+     * rotator "sqrt(2)*c1" should be "sqrt(2)*c6".
+     */
 
-        let tmp10 = tmp0 + tmp3;
-        let tmp13 = tmp0 - tmp3;
-        let tmp11 = tmp1 + tmp2;
-        let tmp12 = tmp1 - tmp2;
+    let tmp10 = tmp0 + tmp3;
+    let tmp13 = tmp0 - tmp3;
+    let tmp11 = tmp1 + tmp2;
+    let tmp12 = tmp1 - tmp2;
 
-        data[DCT_SIZE * 0 + x] = into_el(descale(tmp10 + tmp11, PASS1_BITS));
-        data[DCT_SIZE * 4 + x] = into_el(descale(tmp10 - tmp11, PASS1_BITS));
+    let data_0 = descale_w(tmp10 + tmp11, PASS1_BITS);
+    let data_4 = descale_w(tmp10 - tmp11, PASS1_BITS);
 
-        let z1 = (tmp12 + tmp13) * FIX_0_541196100;
-        data[DCT_SIZE * 2 + x] = into_el(descale(
-            z1 + tmp13 * FIX_0_765366865,
-            CONST_BITS + PASS1_BITS,
-        ));
-        data[DCT_SIZE * 6 + x] = into_el(descale(
-            z1 + tmp12 * -FIX_1_847759065,
-            CONST_BITS + PASS1_BITS,
-        ));
+    let z1 = (tmp12 + tmp13) * FIX_0_541196100;
+    let data_2 = descale_w(z1 + tmp13 * FIX_0_765366865, CONST_BITS + PASS1_BITS);
+    let data_6 = descale_w(z1 + tmp12 * -FIX_1_847759065, CONST_BITS + PASS1_BITS);
 
-        /* Odd part per figure 8 --- note paper omits factor of sqrt(2).
-         * cK represents cos(K*pi/16).
-         * i0..i3 in the paper are tmp4..tmp7 here.
-         */
+    /* Odd part per figure 8 --- note paper omits factor of sqrt(2).
+     * cK represents cos(K*pi/16).
+     * i0..i3 in the paper are tmp4..tmp7 here.
+     */
 
-        let z1 = tmp4 + tmp7;
-        let z2 = tmp5 + tmp6;
-        let z3 = tmp4 + tmp6;
-        let z4 = tmp5 + tmp7;
-        let z5 = (z3 + z4) * FIX_1_175875602; /* sqrt(2) * c3 */
+    let z1 = tmp4 + tmp7;
+    let z2 = tmp5 + tmp6;
+    let z3 = tmp4 + tmp6;
+    let z4 = tmp5 + tmp7;
+    let z5 = (z3 + z4) * FIX_1_175875602; /* sqrt(2) * c3 */
 
-        let tmp4 = tmp4 * FIX_0_298631336; /* sqrt(2) * (-c1+c3+c5-c7) */
-        let tmp5 = tmp5 * FIX_2_053119869; /* sqrt(2) * ( c1+c3-c5+c7) */
-        let tmp6 = tmp6 * FIX_3_072711026; /* sqrt(2) * ( c1+c3+c5-c7) */
-        let tmp7 = tmp7 * FIX_1_501321110; /* sqrt(2) * ( c1+c3-c5-c7) */
-        let z1 = z1 * -FIX_0_899976223; /* sqrt(2) * ( c7-c3) */
-        let z2 = z2 * -FIX_2_562915447; /* sqrt(2) * (-c1-c3) */
-        let z3 = z3 * -FIX_1_961570560; /* sqrt(2) * (-c3-c5) */
-        let z4 = z4 * -FIX_0_390180644; /* sqrt(2) * ( c5-c3) */
+    let tmp4 = tmp4 * FIX_0_298631336; /* sqrt(2) * (-c1+c3+c5-c7) */
+    let tmp5 = tmp5 * FIX_2_053119869; /* sqrt(2) * ( c1+c3-c5+c7) */
+    let tmp6 = tmp6 * FIX_3_072711026; /* sqrt(2) * ( c1+c3+c5-c7) */
+    let tmp7 = tmp7 * FIX_1_501321110; /* sqrt(2) * ( c1+c3-c5-c7) */
+    let z1 = z1 * -FIX_0_899976223; /* sqrt(2) * ( c7-c3) */
+    let z2 = z2 * -FIX_2_562915447; /* sqrt(2) * (-c1-c3) */
+    let z3 = z3 * -FIX_1_961570560; /* sqrt(2) * (-c3-c5) */
+    let z4 = z4 * -FIX_0_390180644; /* sqrt(2) * ( c5-c3) */
 
-        let z3 = z3 + z5;
-        let z4 = z4 + z5;
+    let z3 = z3 + z5;
+    let z4 = z4 + z5;
 
-        data[DCT_SIZE * 7 + x] = into_el(descale(tmp4 + z1 + z3, CONST_BITS + PASS1_BITS));
-        data[DCT_SIZE * 5 + x] = into_el(descale(tmp5 + z2 + z4, CONST_BITS + PASS1_BITS));
-        data[DCT_SIZE * 3 + x] = into_el(descale(tmp6 + z2 + z3, CONST_BITS + PASS1_BITS));
-        data[DCT_SIZE * 1 + x] = into_el(descale(tmp7 + z1 + z4, CONST_BITS + PASS1_BITS));
-    }
+    let data_7 = descale_w(tmp4 + z1 + z3, CONST_BITS + PASS1_BITS);
+    let data_5 = descale_w(tmp5 + z2 + z4, CONST_BITS + PASS1_BITS);
+    let data_3 = descale_w(tmp6 + z2 + z3, CONST_BITS + PASS1_BITS);
+    let data_1 = descale_w(tmp7 + z1 + z4, CONST_BITS + PASS1_BITS);
+
+    *data = cast(
+        [
+            data_0, data_1, data_2, data_3, data_4, data_5, data_6, data_7,
+        ]
+        .map(i16x8::from_i32x8_truncate),
+    );
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The result is a 50% speedup for non-AVX SSE2 (default for rust x86_64). If compiling for AVX2, the code is about 20% slower than the hand-rolled AVX2 code.

The wide crate already has safe abstractions for most of the common CPU architectures, so this means we support for WASM and ARM64 Neon CPUs.

Wide works on stable.