### PR TITLE
Add quality getter and setter to `Encoder`

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -286,6 +286,16 @@ impl<W: JfifWrite> Encoder<W> {
         self.density
     }
 
+    /// Set quality setting. Quality must be between 1 and 100 where 100 is the highest image quality.
+    pub fn set_quality(&mut self, quality: u8) {
+        self.quality = quality;
+    }
+
+    /// Get quality setting
+    pub fn quality(&self) -> u8 {
+        self.quality
+    }
+
     /// Set chroma subsampling factor
     pub fn set_sampling_factor(&mut self, sampling: SamplingFactor) {
         self.sampling_factor = sampling;


### PR DESCRIPTION
It can sometimes be necessary to set the quality after creating the encoder. This wasn't possible, so I added a getter and a setter for the quality setting. 

There are no values in `Encoder` that depend on `self.quality` and would become invalid when it changes. `self.sampling_factor` does depend on the initial `quality` parameter, but it can also be overwritten should `set_quality` be used.